### PR TITLE
Fixed auth bug

### DIFF
--- a/utils/auth.js
+++ b/utils/auth.js
@@ -4,7 +4,7 @@ const { config } = require('../server-config');
 
 exports.verify = token => {
   const secret = config.JWT_SECRET;
-  return jwt.verify(token, Buffer.from(secret, 'base64'), {
+  return jwt.verify(token, Buffer.from(secret), {
     algorithms: [config.JWT_ALGORITHM]
   });
 };


### PR DESCRIPTION
When making a jwt, it used plain form of jwt_secret, however when verifying, it used base64 decoded form of jwt_secret. It caused every verification to turn into failed.
So I fixed it by modifying verify process, now it uses plain form of jwt_secret, just like as issuing a token.